### PR TITLE
Refresh landing and login experiences

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,446 +3,148 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>SNDP Loan Portal — Welcome</title>
+  <title>SNDP Loan Portal — Community-first lending demo</title>
   <link rel="stylesheet" href="styles.css"/>
   <meta name="color-scheme" content="dark light"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&family=Inter:wght@400;600&display=swap" rel="stylesheet"/>
-  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js"></script>
 </head>
-<body class="landing">
-  <div class="landing-hero">
-    <div class="hero-overlay">
-      <header class="header">
-        <div>
-          <div class="title">SNDP Loan Portal</div>
-          <div class="sub">Community savings &amp; credit unions inspired by Sree Narayana Guru</div>
-        </div>
-        <nav class="nav">
-          <a href="README.html">Implementation Guide</a>
-          <a href="#promptCard">AI Data Prompt</a>
-        </nav>
-      </header>
-      <div class="hero-content">
-        <h1>Serve members with confidence.</h1>
-        <p>Use the demo logins below to explore the dual experience — a welcoming public member view and a branch manager cockpit with a top-down view of every account.</p>
-        <div class="pill-list">
-
-
-
-          <span class="pill">Password reset override preview</span>
-
-
-
-          <span class="pill">Branch intelligence dashboard</span>
-          <span class="pill">Excel / PDF exports</span>
-        </div>
+<body class="home">
+  <header class="landing-header">
+    <div class="container header-inner">
+      <div>
+        <div class="title">SNDP Loan Portal</div>
+        <div class="sub">Community savings &amp; credit unions inspired by Sree Narayana Guru</div>
       </div>
+      <nav class="landing-nav">
+        <a href="login.html">Launch portal</a>
+        <a href="README.html">Implementation guide</a>
+        <a href="#features">Features</a>
+      </nav>
     </div>
-  </div>
+  </header>
 
-  <main class="container landing-content">
-    <section class="grid two login-panels">
-      <form id="publicLoginForm" class="card glass login-card">
-        <h3>Member Login</h3>
-        <p class="small">Members view their personal profile, upload receipts, and monitor their loan ledger.</p>
-        <label>Username
-          <input class="input" name="username" id="memberUsername" autocomplete="username" required value="sanoj1"/>
-        </label>
-        <label>Password
-          <input class="input" name="password" type="password" autocomplete="current-password" required value="demo123"/>
-        </label>
-        <div class="form-actions">
-          <button class="btn" type="submit">Sign in as Member</button>
-        </div>
-        <p class="form-message" id="memberMsg"></p>
-        <div class="small">Try <code>sanoj1 / demo123</code> or <code>reshma2 / demo123</code>.</div>
-      </form>
-
-      <form id="managerLoginForm" class="card glass login-card">
-        <h3>Manager Command Center</h3>
-        <p class="small">Managers unlock branch-wide intelligence, audit logging, and rapid access to every account book.</p>
-        <label>Username
-          <input class="input" name="username" id="managerUsername" autocomplete="username" required value="manager"/>
-        </label>
-        <label>Password
-          <input class="input" name="password" type="password" autocomplete="current-password" required value="demo123"/>
-        </label>
-        <div class="form-actions">
-          <button class="btn" type="submit">Sign in as Manager</button>
-        </div>
-        <p class="form-message" id="managerMsg"></p>
-        <div class="small">Try <code>manager / demo123</code> or <code>kochi_mgr / demo123</code>.</div>
-      </form>
-    </section>
-
-    <section class="grid two" style="margin-top:24px;align-items:start">
-      <div class="card glass" id="promptCard">
-        <h3>AI prompt — generate 10 demo members &amp; Excel books</h3>
-        <p class="small">Copy the text below into ChatGPT-5 or another AI assistant. The response will include ten fictional members, ready-to-commit JSON account books, and base64-encoded Excel files you can decode for direct download.</p>
-        <textarea id="aiPrompt" class="prompt-box" rows="12" readonly>
-You are ChatGPT-5 acting as a dataset generator for the "SNDP Loan Portal" GitHub Pages demo.
-
-Produce TEN fictional SNDP micro-loan members spread across multiple Kerala branches. For each member:
-1. Output a JSON object that matches data/users.json with fields:
-   - username (lowercase, unique)
-   - role = "member"
-   - branch (existing or new chapter id)
-   - permissions = ["profile:read","profile:update","accounts:read"]
-   - full_name, dob (YYYY-MM-DD), address, phone, email, photo = "data/profile_photos/jyo.svg"
-   - account_excel = "data/accounts/&lt;username&gt;_account.json"
-   - salt and password_hash for the password "demo123" using SHA-256(salt+password) with random 16-char hex salt.
-2. Output a companion JSON file named data/accounts/&lt;username&gt;_account.json with fields {"owner","branch","generated", "account": [ ... ]}.
-   - Include 18–24 ledger rows over the last 12 months with columns Date (YYYY-MM-DD), Description, Type (Loan, Repayment, Interest, Fee), Amount (positive for disbursements, negative for repayments), Notes.
-3. Create an Excel workbook for each member with a sheet "Account" matching the JSON rows, plus a Balance column that cumulatively sums Amount. Return each workbook as base64 for a binary .xlsx file under a key xlsx_base64 inside the account JSON response.
-
-Respond with:
-{
-  "users": [ ... ten user objects ... ],
-  "accounts": {
-     "&lt;username&gt;_account.json": {
-        "owner": "...",
-        "branch": "...",
-        "generated": "ISO timestamp",
-        "account": [...rows...],
-        "xlsx_base64": "base64 encoded .xlsx file for this member"
-     },
-     ... nine more ...
-  }
-}
-
-        </textarea>
-        <div style="margin-top:12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-          <button class="btn" type="button" onclick="copyPrompt()">Copy prompt</button>
-          <button class="btn ghost" type="button" onclick="downloadSampleWorkbook()">Download sample Excel</button>
-          <span id="promptMsg" class="small" style="flex:1 1 180px"></span>
-        </div>
-      </div>
-
-    <div class="grid two">
-      <div class="card">
-        <h3>Login</h3>
-        <p class="small">Use the demo accounts below to sign in. All verification happens in your browser.</p>
-        <form id="loginForm">
-          <label>Username</label>
-          <input class="input" id="username" autocomplete="username" required value="manager"/>
-          <label>Password</label>
-          <input class="input" id="password" type="password" autocomplete="current-password" required value="demo123"/>
-          <div style="margin-top:12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-            <button class="btn" type="submit">Sign in</button>
-            <span id="loginMsg" class="small" style="flex:1 1 160px"></span>
+  <main>
+    <section class="hero">
+      <div class="container hero-grid">
+        <div class="hero-copy">
+          <span class="eyebrow">Branch-ready &bull; Client-side only demo</span>
+          <h1>Serve every SNDP member with clarity, empathy, and speed.</h1>
+          <p>The refreshed landing experience introduces a clear path into the browser-based loan portal while keeping every feature available for self-paced exploration.</p>
+          <div class="hero-actions">
+            <a class="btn" href="login.html">Sign in to the loan portal</a>
+            <a class="btn ghost" href="README.html">Review deployment notes</a>
           </div>
-        </form>
-
-      </div>
-
-      <div class="card glass">
-        <h3>How the demo works</h3>
-        <ul class="small feature-list">
-          <li>Branch-aware dashboard summarises total loaned, repayments, and outstanding balance for every member.</li>
-          <li>Members can export Excel snapshots, fetch monthly PDF statements, and manage receipt attachments locally.</li>
-
-
-
-          <li>Password reset uses an in-browser override stored locally for this static prototype.</li>
-
-
-
-          <li>All data loads from <code>data/*.json</code>, making the project Git-friendly and easy to extend.</li>
-        </ul>
-        <div class="card ghost" style="margin-top:12px">
-          <div class="small">Need more guidance?</div>
-          <a class="btn" href="README.html" style="margin-top:8px">Open the onboarding guide</a>
+          <dl class="hero-stats">
+            <div>
+              <dt>Total demo members</dt>
+              <dd>16+</dd>
+            </div>
+            <div>
+              <dt>Manager oversight panels</dt>
+              <dd>3</dd>
+            </div>
+            <div>
+              <dt>Exports &amp; statements</dt>
+              <dd>Excel &amp; PDF</dd>
+            </div>
+          </dl>
+        </div>
+        <div class="hero-media">
+          <div class="media-frame">
+            <div class="media-card">
+              <div class="media-card__header">
+                <span class="badge">Manager dashboard</span>
+                <span class="badge ghost">Real data</span>
+              </div>
+              <div class="media-card__body">
+                <ul>
+                  <li><strong>Branch totals</strong> for loaned, repaid, and outstanding balances.</li>
+                  <li><strong>One-click exports</strong> for Excel account books and PDF statements.</li>
+                  <li><strong>Password reset overrides</strong> with OTP preview for this static prototype.</li>
+                </ul>
+              </div>
+            </div>
+            <div class="media-card">
+              <div class="media-card__header">
+                <span class="badge">Member workspace</span>
+                <span class="badge ghost">In-browser only</span>
+              </div>
+              <div class="media-card__body">
+                <ul>
+                  <li>Editable profile with local photo capture and attachment vault.</li>
+                  <li>Interactive ledger with running balance and interest projection.</li>
+                  <li>Receipts stay on-device to respect the static GitHub Pages setup.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>
 
-    <footer>© SNDP Demo • Built for GitHub Pages • Featuring Sree Narayana Guru</footer>
+    <section id="features" class="container features-section">
+      <header class="section-header">
+        <span class="eyebrow">What&apos;s inside</span>
+        <h2>Dual experiences for members and branch managers</h2>
+        <p>Every interaction is performed in your browser. Use the loan portal to explore realistic SNDP workflows backed by JSON datasets and downloadable ledgers.</p>
+      </header>
+      <div class="features-grid">
+        <article class="feature-card">
+          <h3>Member login</h3>
+          <p>Members track repayments, upload receipts, and export personalised Excel workbooks.</p>
+          <a class="inline-link" href="login.html#member">Try <code>sanoj1 / demo123</code></a>
+        </article>
+        <article class="feature-card">
+          <h3>Manager command</h3>
+          <p>Managers oversee every branch account with audit logging and intelligent filters.</p>
+          <a class="inline-link" href="login.html#manager">Try <code>manager / demo123</code></a>
+        </article>
+        <article class="feature-card">
+          <h3>Rapid dataset generation</h3>
+          <p>Use our ready-made AI prompt to generate JSON users, ledgers, and Excel workbooks in a single response.</p>
+          <a class="inline-link" href="login.html#promptCard">Copy the AI prompt</a>
+        </article>
+        <article class="feature-card">
+          <h3>GitHub Pages friendly</h3>
+          <p>All logic runs locally. Update <code>data/*.json</code> and ship instantly without build steps.</p>
+          <a class="inline-link" href="README.html">Read the implementation guide</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="container spotlight">
+      <div class="spotlight-card">
+        <header class="spotlight__head">
+          <span class="eyebrow">Fast start</span>
+          <h2>Copy, paste, and populate your own cooperative in minutes.</h2>
+        </header>
+        <div class="spotlight__body">
+          <ol>
+            <li>Open the AI dataset prompt to generate 10 fresh member ledgers.</li>
+            <li>Drop the exported JSON files into <code>data/users.json</code> and <code>data/accounts/</code>.</li>
+            <li>Commit changes to GitHub Pages—no servers, databases, or build steps required.</li>
+          </ol>
+        </div>
+        <div class="spotlight__cta">
+          <a class="btn" href="login.html#promptCard">Open the AI prompt</a>
+          <a class="btn ghost" href="data/accounts/sample_account.json">Preview sample ledger JSON</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="container cta">
+      <div class="cta-card">
+        <div>
+          <h2>Ready to explore the live demo?</h2>
+          <p>Sign in as a member or manager to experience the refreshed SNDP loan portal. All existing functionality remains, just one click away.</p>
+        </div>
+        <a class="btn" href="login.html">Launch the login hub</a>
+      </div>
+    </section>
   </main>
 
-
-
-  <div id="resetModal" class="modal hidden">
-    <div class="modal-panel">
-      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
-        <h3 style="margin:0">Reset password</h3>
-        <button class="btn ghost" type="button" onclick="closeReset()">Close</button>
-      </div>
-
-      <p class="small">Enter your username to receive a one-time password (OTP). For this offline demo the OTP is shown onscreen instead of being emailed.</p>
-      <div class="grid two" style="grid-template-columns:1fr">
-        <label>Username<input class="input" id="resetUser"/></label>
-        <button class="btn" type="button" onclick="sendOtp()">Send OTP</button>
-        <div id="otpArea" class="hidden">
-          <label>Enter OTP<input class="input" id="otpInput"/></label>
-          <label>New password<input class="input" id="newPassword" type="password"/></label>
-          <button class="btn" type="button" onclick="submitReset()">Update password</button>
-          <p id="otpStatus" class="small"></p>
-        </div>
-        <p id="otpHint" class="small"></p>
-
-      </div>
-    </div>
-  </div>
-
-
-
-  <script>
-  const USER_CACHE = {data: null};
-
-  async function sha256Hex(str){
-    const enc = new TextEncoder().encode(str);
-    const buf = await crypto.subtle.digest('SHA-256', enc);
-    const bytes = Array.from(new Uint8Array(buf));
-    return bytes.map(b => b.toString(16).padStart(2, '0')).join('');
-  }
-
-  function recordAudit(entry){
-    try{
-      const list = JSON.parse(localStorage.getItem('audit_log') || '[]');
-      list.push({...entry, ts: new Date().toISOString()});
-      while(list.length > 500){ list.shift(); }
-      localStorage.setItem('audit_log', JSON.stringify(list));
-    }catch(err){
-      console.error('audit log failed', err);
-    }
-  }
-
-
-
-
-  function applyPasswordOverride(rec){
-    try{
-      const override = JSON.parse(localStorage.getItem('override_' + rec.username) || 'null');
-      if(override && override.password_hash && override.salt){
-        return {...rec, salt: override.salt, password_hash: override.password_hash};
-      }
-    }catch(err){
-      console.warn('override parse failed', err);
-    }
-    return rec;
-  }
-
-  async function loadUsers(){
-    if(USER_CACHE.data){
-      return USER_CACHE.data;
-    }
-    const res = await fetch('data/users.json');
-    if(!res.ok){
-      throw new Error('Unable to load users.json');
-    }
-    USER_CACHE.data = await res.json();
-    return USER_CACHE.data;
-  }
-
-
-  function getFormMessage(form){
-    return form.querySelector('.form-message') || document.getElementById('loginMsg');
-  }
-
-
-
-
-
-  async function handleLogin(ev, expectedRole){
-    ev.preventDefault();
-    const form = ev.target;
-    const userField = form.querySelector('input[name="username"], input#username');
-    const passField = form.querySelector('input[name="password"], input#password');
-    const msg = getFormMessage(form);
-    const username = (userField?.value || '').trim();
-    const password = passField?.value || '';
-
-    if(msg){ msg.textContent = 'Checking…'; }
-    try{
-      const db = await loadUsers();
-      let rec = db.users.find(x => x.username === username);
-      if(!rec){
-        if(msg){ msg.textContent = 'User not found'; }
-        return;
-      }
-      if(expectedRole === 'manager' && rec.role !== 'manager'){
-        if(msg){ msg.textContent = 'Use the manager panel to sign in'; }
-        return;
-      }
-      if(expectedRole === 'member' && rec.role !== 'member'){
-        if(msg){ msg.textContent = 'Use the manager login instead'; }
-        return;
-      }
-
-
-
-
-      rec = applyPasswordOverride(rec);
-
-      const hash = await sha256Hex(rec.salt + password);
-      if(hash !== rec.password_hash){
-        if(msg){ msg.textContent = 'Invalid password'; }
-        return;
-      }
-
-
-
-      const session = {
-        username: rec.username,
-        role: rec.role,
-        branch: rec.branch || null,
-        permissions: rec.permissions || [],
-        ts: Date.now()
-      };
-      localStorage.setItem('sndp_session', JSON.stringify(session));
-      recordAudit({actor: rec.username, action: 'login', branch: rec.branch || null});
-      if(msg){ msg.textContent = 'Login successful. Redirecting…'; }
-      location.href = 'app.html';
-    }catch(err){
-      console.error(err);
-      if(msg){ msg.textContent = 'Unable to load users'; }
-    }
-  }
-
-
-
-
-  function openReset(prefillId){
-    if(prefillId){
-      const field = document.getElementById(prefillId);
-      if(field){
-        const value = field.value || field.getAttribute('placeholder') || '';
-        document.getElementById('resetUser').value = value;
-      }
-    }
-    document.getElementById('resetModal').classList.remove('hidden');
-    document.getElementById('resetUser').focus();
-  }
-
-  function closeReset(){
-    document.getElementById('resetModal').classList.add('hidden');
-    document.getElementById('resetUser').value = '';
-
-    document.getElementById('otpArea').classList.add('hidden');
-    document.getElementById('otpStatus').textContent = '';
-    document.getElementById('otpHint').textContent = '';
-  }
-
-  async function sendOtp(){
-    const user = document.getElementById('resetUser').value.trim();
-    if(!user){ alert('Enter username'); return; }
-    const db = await loadUsers();
-    const rec = db.users.find(x => x.username === user);
-    if(!rec){ alert('User not found'); return; }
-    const code = Math.floor(100000 + Math.random() * 900000).toString();
-    localStorage.setItem('otp_' + user, JSON.stringify({code, expires: Date.now() + 10 * 60 * 1000}));
-    document.getElementById('otpArea').classList.remove('hidden');
-    document.getElementById('otpStatus').textContent = '';
-    document.getElementById('otpHint').textContent = `OTP for demo purposes: ${code}`;
-    recordAudit({actor: user, action: 'otp_sent', branch: rec.branch || null});
-  }
-
-  async function submitReset(){
-
-    const user = document.getElementById('resetUser').value.trim();
-    const pass = document.getElementById('newPassword').value;
-
-    const status = document.getElementById('otpStatus');
-    if(!otp || !pass){ status.textContent = 'Enter OTP and new password'; return; }
-    const stored = localStorage.getItem('otp_' + user);
-    if(!stored){ status.textContent = 'No OTP found, request again.'; return; }
-    const rec = JSON.parse(stored);
-    if(Date.now() > rec.expires){ status.textContent = 'OTP expired. Request a new one.'; return; }
-    if(rec.code !== otp){ status.textContent = 'Incorrect OTP.'; return; }
-    const salt = Array.from(crypto.getRandomValues(new Uint8Array(8))).map(b => b.toString(16).padStart(2, '0')).join('');
-    const hash = await sha256Hex(salt + pass);
-    localStorage.setItem('override_' + user, JSON.stringify({salt, password_hash: hash}));
-    localStorage.removeItem('otp_' + user);
-
-    status.textContent = 'Password updated. You can now sign in.';
-    recordAudit({actor: user, action: 'password_reset_override', branch: rec.branch || null});
-  }
-
-
-
-
-  async function downloadSampleWorkbook(){
-    try{
-      const res = await fetch('data/accounts/sample_account.json');
-      const payload = await res.json();
-      const dataset = Array.isArray(payload.account) ? payload.account : (payload.rows || []);
-      const rows = dataset.map(row => ({...row}));
-      let running = 0;
-      const sheetRows = rows.map(r => {
-        const amt = typeof r.Amount === 'number' ? r.Amount : parseFloat(r.Amount || 0) || 0;
-        running += amt;
-        return {...r, Balance: running};
-      });
-      const ws = XLSX.utils.json_to_sheet(sheetRows);
-      const wb = XLSX.utils.book_new();
-      XLSX.utils.book_append_sheet(wb, ws, 'Account');
-      const wbout = XLSX.write(wb, {bookType: 'xlsx', type: 'array'});
-      const blob = new Blob([wbout], {type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'});
-      const a = document.createElement('a');
-      a.href = URL.createObjectURL(blob);
-      a.download = 'sample_account_book.xlsx';
-      a.click();
-      URL.revokeObjectURL(a.href);
-      const msg = document.getElementById('promptMsg');
-      if(msg){ msg.textContent = 'Sample Excel downloaded. Import it into Excel or LibreOffice to explore the format.'; }
-    }catch(err){
-      console.error(err);
-      const msg = document.getElementById('promptMsg');
-      if(msg){ msg.textContent = 'Unable to load sample_account.json'; }
-    }
-  }
-
-  async function copyPrompt(){
-    const prompt = document.getElementById('aiPrompt').value;
-    try{
-      await navigator.clipboard.writeText(prompt);
-      const msg = document.getElementById('promptMsg');
-      if(msg){ msg.textContent = 'Prompt copied to clipboard.'; }
-    }catch(err){
-      console.error(err);
-      const msg = document.getElementById('promptMsg');
-      if(msg){ msg.textContent = 'Copy failed — please select and copy manually.'; }
-    }
-  }
-
-  function initLoginPanels(){
-    const memberForm = document.getElementById('publicLoginForm');
-    if(memberForm){ memberForm.addEventListener('submit', ev => handleLogin(ev, 'member')); }
-    const managerForm = document.getElementById('managerLoginForm');
-    if(managerForm){ managerForm.addEventListener('submit', ev => handleLogin(ev, 'manager')); }
-    const genericForm = document.getElementById('loginForm');
-    if(genericForm){ genericForm.addEventListener('submit', ev => handleLogin(ev, 'any')); }
-
-
-
-    document.querySelectorAll('button[data-reset]').forEach(btn => {
-      btn.addEventListener('click', () => openReset(btn.getAttribute('data-reset')));
-    });
-
-
-
-  }
-
-  document.addEventListener('DOMContentLoaded', () => {
-    initLoginPanels();
-  });
-
-
-
-
-  window.openReset = openReset;
-  window.closeReset = closeReset;
-
-  window.sendOtp = sendOtp;
-  window.submitReset = submitReset;
-
-
-
-  window.downloadSampleWorkbook = downloadSampleWorkbook;
-  window.copyPrompt = copyPrompt;
-
-  </script>
+  <footer class="landing-footer">© SNDP Demo • Built for GitHub Pages • Featuring Sree Narayana Guru</footer>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>SNDP Loan Portal — Login hub</title>
+  <link rel="stylesheet" href="styles.css"/>
+  <meta name="color-scheme" content="dark light"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&family=Inter:wght@400;600&display=swap" rel="stylesheet"/>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js"></script>
+</head>
+<body class="login-page">
+  <header class="landing-header compact">
+    <div class="container header-inner">
+      <div>
+        <div class="title">SNDP Loan Portal</div>
+        <div class="sub">Secure browser-based access for members and managers</div>
+      </div>
+      <nav class="landing-nav">
+        <a href="index.html">Home</a>
+        <a href="README.html">Implementation guide</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container login-layout">
+    <aside class="login-side">
+      <div class="login-side__intro">
+        <span class="eyebrow">Login hub</span>
+        <h1>Choose your role to begin.</h1>
+        <p>This page retains every feature from the previous landing screen, now arranged for focused sign-ins and quick dataset generation.</p>
+      </div>
+      <div class="login-side__cards">
+        <div class="info-card">
+          <h3>Member quick start</h3>
+          <p class="small">Try <code>sanoj1 / demo123</code> or <code>reshma2 / demo123</code> to explore personal ledgers and receipt uploads.</p>
+        </div>
+        <div class="info-card">
+          <h3>Manager quick start</h3>
+          <p class="small">Use <code>manager / demo123</code> or <code>kochi_mgr / demo123</code> for branch intelligence and audit logs.</p>
+        </div>
+        <div class="info-card">
+          <h3>Need credentials?</h3>
+          <p class="small">All demo accounts live in <code>data/users.json</code>. Update them locally to create new logins.</p>
+        </div>
+      </div>
+    </aside>
+
+    <section class="login-main" aria-labelledby="member">
+      <div class="login-panels">
+        <form id="publicLoginForm" class="card glass login-card" aria-labelledby="member">
+          <h2 id="member">Member login</h2>
+          <p class="small">Members view their personal profile, upload receipts, and monitor their loan ledger.</p>
+          <label>Username
+            <input class="input" name="username" id="memberUsername" autocomplete="username" required value="sanoj1"/>
+          </label>
+          <label>Password
+            <input class="input" name="password" type="password" autocomplete="current-password" required value="demo123"/>
+          </label>
+          <div class="form-actions">
+            <button class="btn" type="submit">Sign in as member</button>
+            <button class="btn ghost" type="button" data-reset="memberUsername">Forgot password?</button>
+          </div>
+          <p class="form-message" id="memberMsg"></p>
+        </form>
+
+        <form id="managerLoginForm" class="card glass login-card" aria-labelledby="manager">
+          <h2 id="manager">Manager command center</h2>
+          <p class="small">Managers unlock branch-wide intelligence, audit logging, and rapid access to every account book.</p>
+          <label>Username
+            <input class="input" name="username" id="managerUsername" autocomplete="username" required value="manager"/>
+          </label>
+          <label>Password
+            <input class="input" name="password" type="password" autocomplete="current-password" required value="demo123"/>
+          </label>
+          <div class="form-actions">
+            <button class="btn" type="submit">Sign in as manager</button>
+            <button class="btn ghost" type="button" data-reset="managerUsername">Forgot password?</button>
+          </div>
+          <p class="form-message" id="managerMsg"></p>
+        </form>
+      </div>
+
+      <div class="card stack-card">
+        <h2>Universal demo login</h2>
+        <p class="small">Use any credential pair from <code>data/users.json</code>. All verification happens in your browser, with optional password overrides stored locally.</p>
+        <form id="loginForm">
+          <label>Username
+            <input class="input" id="username" autocomplete="username" required value="manager"/>
+          </label>
+          <label>Password
+            <input class="input" id="password" type="password" autocomplete="current-password" required value="demo123"/>
+          </label>
+          <div class="form-actions">
+            <button class="btn" type="submit">Sign in</button>
+            <span id="loginMsg" class="small"></span>
+          </div>
+        </form>
+      </div>
+
+      <div id="promptCard" class="card glass stack-card">
+        <h2>AI prompt — generate 10 demo members &amp; Excel books</h2>
+        <p class="small">Copy the text below into ChatGPT-5 or another AI assistant. The response will include ten fictional members, JSON account books, and base64-encoded Excel files.</p>
+        <textarea id="aiPrompt" class="prompt-box" rows="12" readonly>
+You are ChatGPT-5 acting as a dataset generator for the "SNDP Loan Portal" GitHub Pages demo.
+
+Produce TEN fictional SNDP micro-loan members spread across multiple Kerala branches. For each member:
+1. Output a JSON object that matches data/users.json with fields:
+   - username (lowercase, unique)
+   - role = "member"
+   - branch (existing or new chapter id)
+   - permissions = ["profile:read","profile:update","accounts:read"]
+   - full_name, dob (YYYY-MM-DD), address, phone, email, photo = "data/profile_photos/jyo.svg"
+   - account_excel = "data/accounts/<username>_account.json"
+   - salt and password_hash for the password "demo123" using SHA-256(salt+password) with random 16-char hex salt.
+2. Output a companion JSON file named data/accounts/<username>_account.json with fields {"owner","branch","generated", "account": [ ... ]}.
+   - Include 18–24 ledger rows over the last 12 months with columns Date (YYYY-MM-DD), Description, Type (Loan, Repayment, Interest, Fee), Amount (positive for disbursements, negative for repayments), Notes.
+3. Create an Excel workbook for each member with a sheet "Account" matching the JSON rows, plus a Balance column that cumulatively sums Amount. Return each workbook as base64 for a binary .xlsx file under a key xlsx_base64 inside the account JSON response.
+
+Respond with:
+{
+  "users": [ ... ten user objects ... ],
+  "accounts": {
+     "<username>_account.json": {
+        "owner": "...",
+        "branch": "...",
+        "generated": "ISO timestamp",
+        "account": [...rows...],
+        "xlsx_base64": "base64 encoded .xlsx file for this member"
+     },
+     ... nine more ...
+  }
+}
+        </textarea>
+        <div class="prompt-actions">
+          <button class="btn" type="button" onclick="copyPrompt()">Copy prompt</button>
+          <button class="btn ghost" type="button" onclick="downloadSampleWorkbook()">Download sample Excel</button>
+          <span id="promptMsg" class="small"></span>
+        </div>
+      </div>
+
+      <div class="card stack-card">
+        <h2>How the demo works</h2>
+        <ul class="small feature-list">
+          <li>Branch-aware dashboard summarises total loaned, repayments, and outstanding balance for every member.</li>
+          <li>Members can export Excel snapshots, fetch monthly PDF statements, and manage receipt attachments locally.</li>
+          <li>Password reset uses an in-browser override stored locally for this static prototype.</li>
+          <li>All data loads from <code>data/*.json</code>, making the project Git-friendly and easy to extend.</li>
+        </ul>
+        <div class="info-card ghost">
+          <div class="small">Need more guidance?</div>
+          <a class="btn" href="README.html">Open the onboarding guide</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="landing-footer">© SNDP Demo • Client-side only • For evaluation purposes</footer>
+
+  <div id="resetModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="resetTitle">
+    <div class="modal-panel">
+      <div class="modal-head">
+        <h2 id="resetTitle">Reset password</h2>
+        <button class="btn ghost" type="button" onclick="closeReset()">Close</button>
+      </div>
+      <p class="small">Enter your username to receive a one-time password (OTP). For this offline demo the OTP is shown onscreen instead of being emailed.</p>
+      <div class="grid single">
+        <label>Username<input class="input" id="resetUser"/></label>
+        <button class="btn" type="button" onclick="sendOtp()">Send OTP</button>
+        <div id="otpArea" class="hidden">
+          <label>Enter OTP<input class="input" id="otpInput"/></label>
+          <label>New password<input class="input" id="newPassword" type="password"/></label>
+          <button class="btn" type="button" onclick="submitReset()">Update password</button>
+          <p id="otpStatus" class="small"></p>
+        </div>
+        <p id="otpHint" class="small"></p>
+      </div>
+    </div>
+  </div>
+
+  <script src="scripts/auth.js"></script>
+</body>
+</html>

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,0 +1,316 @@
+const USER_CACHE = { data: null };
+
+async function sha256Hex(str) {
+  const enc = new TextEncoder().encode(str);
+  const buf = await crypto.subtle.digest('SHA-256', enc);
+  const bytes = Array.from(new Uint8Array(buf));
+  return bytes.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function recordAudit(entry) {
+  try {
+    const list = JSON.parse(localStorage.getItem('audit_log') || '[]');
+    list.push({ ...entry, ts: new Date().toISOString() });
+    while (list.length > 500) {
+      list.shift();
+    }
+    localStorage.setItem('audit_log', JSON.stringify(list));
+  } catch (err) {
+    console.error('audit log failed', err);
+  }
+}
+
+function applyPasswordOverride(rec) {
+  try {
+    const override = JSON.parse(localStorage.getItem('override_' + rec.username) || 'null');
+    if (override && override.password_hash && override.salt) {
+      return { ...rec, salt: override.salt, password_hash: override.password_hash };
+    }
+  } catch (err) {
+    console.warn('override parse failed', err);
+  }
+  return rec;
+}
+
+async function loadUsers() {
+  if (USER_CACHE.data) {
+    return USER_CACHE.data;
+  }
+  const res = await fetch('data/users.json');
+  if (!res.ok) {
+    throw new Error('Unable to load users.json');
+  }
+  USER_CACHE.data = await res.json();
+  return USER_CACHE.data;
+}
+
+function getFormMessage(form) {
+  return form.querySelector('.form-message') || document.getElementById('loginMsg');
+}
+
+async function handleLogin(ev, expectedRole) {
+  ev.preventDefault();
+  const form = ev.target;
+  const userField = form.querySelector('input[name="username"], input#username');
+  const passField = form.querySelector('input[name="password"], input#password');
+  const msg = getFormMessage(form);
+  const username = (userField?.value || '').trim();
+  const password = passField?.value || '';
+
+  if (msg) {
+    msg.textContent = 'Checking…';
+  }
+  try {
+    const db = await loadUsers();
+    let rec = db.users.find(x => x.username === username);
+    if (!rec) {
+      if (msg) {
+        msg.textContent = 'User not found';
+      }
+      return;
+    }
+    if (expectedRole === 'manager' && rec.role !== 'manager') {
+      if (msg) {
+        msg.textContent = 'Use the manager panel to sign in';
+      }
+      return;
+    }
+    if (expectedRole === 'member' && rec.role !== 'member') {
+      if (msg) {
+        msg.textContent = 'Use the manager login instead';
+      }
+      return;
+    }
+
+    rec = applyPasswordOverride(rec);
+
+    const hash = await sha256Hex(rec.salt + password);
+    if (hash !== rec.password_hash) {
+      if (msg) {
+        msg.textContent = 'Invalid password';
+      }
+      return;
+    }
+
+    const session = {
+      username: rec.username,
+      role: rec.role,
+      branch: rec.branch || null,
+      permissions: rec.permissions || [],
+      ts: Date.now()
+    };
+    localStorage.setItem('sndp_session', JSON.stringify(session));
+    recordAudit({ actor: rec.username, action: 'login', branch: rec.branch || null });
+    if (msg) {
+      msg.textContent = 'Login successful. Redirecting…';
+    }
+    location.href = 'app.html';
+  } catch (err) {
+    console.error(err);
+    if (msg) {
+      msg.textContent = 'Unable to load users';
+    }
+  }
+}
+
+function openReset(prefillId) {
+  const modal = document.getElementById('resetModal');
+  if (!modal) {
+    return;
+  }
+  if (prefillId) {
+    const field = document.getElementById(prefillId);
+    if (field) {
+      const value = field.value || field.getAttribute('placeholder') || '';
+      const resetField = document.getElementById('resetUser');
+      if (resetField) {
+        resetField.value = value;
+      }
+    }
+  }
+  modal.classList.remove('hidden');
+  const resetInput = document.getElementById('resetUser');
+  if (resetInput) {
+    resetInput.focus();
+  }
+}
+
+function closeReset() {
+  const modal = document.getElementById('resetModal');
+  if (!modal) {
+    return;
+  }
+  modal.classList.add('hidden');
+  const resetUser = document.getElementById('resetUser');
+  if (resetUser) {
+    resetUser.value = '';
+  }
+  const area = document.getElementById('otpArea');
+  if (area) {
+    area.classList.add('hidden');
+  }
+  const status = document.getElementById('otpStatus');
+  const hint = document.getElementById('otpHint');
+  if (status) {
+    status.textContent = '';
+  }
+  if (hint) {
+    hint.textContent = '';
+  }
+}
+
+async function sendOtp() {
+  const user = document.getElementById('resetUser')?.value.trim();
+  if (!user) {
+    alert('Enter username');
+    return;
+  }
+  const db = await loadUsers();
+  const rec = db.users.find(x => x.username === user);
+  if (!rec) {
+    alert('User not found');
+    return;
+  }
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+  localStorage.setItem('otp_' + user, JSON.stringify({ code, expires: Date.now() + 10 * 60 * 1000 }));
+  const area = document.getElementById('otpArea');
+  if (area) {
+    area.classList.remove('hidden');
+  }
+  const status = document.getElementById('otpStatus');
+  if (status) {
+    status.textContent = '';
+  }
+  const hint = document.getElementById('otpHint');
+  if (hint) {
+    hint.textContent = `OTP for demo purposes: ${code}`;
+  }
+  recordAudit({ actor: user, action: 'otp_sent', branch: rec.branch || null });
+}
+
+async function submitReset() {
+  const user = document.getElementById('resetUser')?.value.trim();
+  const otp = document.getElementById('otpInput')?.value.trim();
+  const pass = document.getElementById('newPassword')?.value;
+  const status = document.getElementById('otpStatus');
+  if (!otp || !pass) {
+    if (status) {
+      status.textContent = 'Enter OTP and new password';
+    }
+    return;
+  }
+  const stored = localStorage.getItem('otp_' + user);
+  if (!stored) {
+    if (status) {
+      status.textContent = 'No OTP found, request again.';
+    }
+    return;
+  }
+  const rec = JSON.parse(stored);
+  if (Date.now() > rec.expires) {
+    if (status) {
+      status.textContent = 'OTP expired. Request a new one.';
+    }
+    return;
+  }
+  if (rec.code !== otp) {
+    if (status) {
+      status.textContent = 'Incorrect OTP.';
+    }
+    return;
+  }
+  const salt = Array.from(crypto.getRandomValues(new Uint8Array(8))).map(b => b.toString(16).padStart(2, '0')).join('');
+  const hash = await sha256Hex(salt + pass);
+  localStorage.setItem('override_' + user, JSON.stringify({ salt, password_hash: hash }));
+  localStorage.removeItem('otp_' + user);
+  if (status) {
+    status.textContent = 'Password updated. You can now sign in.';
+  }
+  recordAudit({ actor: user, action: 'password_reset_override', branch: rec.branch || null });
+}
+
+async function downloadSampleWorkbook() {
+  if (typeof XLSX === 'undefined') {
+    alert('Excel helper not loaded.');
+    return;
+  }
+  try {
+    const res = await fetch('data/accounts/sample_account.json');
+    const payload = await res.json();
+    const dataset = Array.isArray(payload.account) ? payload.account : (payload.rows || []);
+    const rows = dataset.map(row => ({ ...row }));
+    let running = 0;
+    const sheetRows = rows.map(r => {
+      const amt = typeof r.Amount === 'number' ? r.Amount : parseFloat(r.Amount || 0) || 0;
+      running += amt;
+      return { ...r, Balance: running };
+    });
+    const ws = XLSX.utils.json_to_sheet(sheetRows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Account');
+    const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'sample_account_book.xlsx';
+    a.click();
+    URL.revokeObjectURL(a.href);
+    const msg = document.getElementById('promptMsg');
+    if (msg) {
+      msg.textContent = 'Sample Excel downloaded. Import it into Excel or LibreOffice to explore the format.';
+    }
+  } catch (err) {
+    console.error(err);
+    const msg = document.getElementById('promptMsg');
+    if (msg) {
+      msg.textContent = 'Unable to load sample_account.json';
+    }
+  }
+}
+
+async function copyPrompt() {
+  const prompt = document.getElementById('aiPrompt')?.value || '';
+  try {
+    await navigator.clipboard.writeText(prompt);
+    const msg = document.getElementById('promptMsg');
+    if (msg) {
+      msg.textContent = 'Prompt copied to clipboard.';
+    }
+  } catch (err) {
+    console.error(err);
+    const msg = document.getElementById('promptMsg');
+    if (msg) {
+      msg.textContent = 'Copy failed — please select and copy manually.';
+    }
+  }
+}
+
+function initLoginPanels() {
+  const memberForm = document.getElementById('publicLoginForm');
+  if (memberForm) {
+    memberForm.addEventListener('submit', ev => handleLogin(ev, 'member'));
+  }
+  const managerForm = document.getElementById('managerLoginForm');
+  if (managerForm) {
+    managerForm.addEventListener('submit', ev => handleLogin(ev, 'manager'));
+  }
+  const genericForm = document.getElementById('loginForm');
+  if (genericForm) {
+    genericForm.addEventListener('submit', ev => handleLogin(ev, 'any'));
+  }
+
+  document.querySelectorAll('button[data-reset]').forEach(btn => {
+    btn.addEventListener('click', () => openReset(btn.getAttribute('data-reset')));
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initLoginPanels();
+});
+
+window.openReset = openReset;
+window.closeReset = closeReset;
+window.sendOtp = sendOtp;
+window.submitReset = submitReset;
+window.downloadSampleWorkbook = downloadSampleWorkbook;
+window.copyPrompt = copyPrompt;

--- a/styles.css
+++ b/styles.css
@@ -40,3 +40,89 @@ footer{margin:22px 0;color:var(--muted);font-size:12px;text-align:center}
 .log-table table{width:100%;border-collapse:collapse;font-size:12px}
 .log-table th,.log-table td{padding:6px 8px;border-bottom:1px solid rgba(255,255,255,.06)}
 
+body.home{background:radial-gradient(circle at top,#10213a,#060b18 55%)}
+.landing-header{position:sticky;top:0;z-index:20;background:rgba(6,11,24,.82);backdrop-filter:blur(12px);border-bottom:1px solid rgba(255,255,255,.04)}
+.landing-header.compact{position:static;background:rgba(6,11,24,.9)}
+.header-inner{display:flex;justify-content:space-between;align-items:center;gap:16px;padding:18px 0}
+.landing-nav{display:flex;gap:12px;flex-wrap:wrap}
+.landing-nav a{padding:8px 14px;border-radius:12px;background:rgba(255,255,255,.06);color:var(--text);font-weight:600}
+.landing-nav a:hover{background:rgba(255,255,255,.1)}
+
+.hero{padding:72px 0 48px}
+.hero-grid{display:grid;gap:32px;align-items:center}
+.hero-copy h1{font-size:40px;line-height:1.2;margin-bottom:12px}
+.hero-copy p{max-width:520px;font-size:16px;color:var(--muted)}
+.hero-actions{display:flex;gap:12px;flex-wrap:wrap;margin:24px 0}
+.hero-stats{display:flex;flex-wrap:wrap;gap:24px;margin:24px 0 0;padding:0}
+.hero-stats div{background:rgba(255,255,255,.04);padding:14px 18px;border-radius:16px;min-width:140px}
+.hero-stats dt{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);margin-bottom:4px}
+.hero-stats dd{margin:0;font-size:22px;font-weight:700}
+.hero-media{display:flex;justify-content:center}
+.media-frame{display:grid;gap:18px}
+.media-card{background:linear-gradient(160deg,rgba(13,25,44,.9),rgba(13,25,44,.6));border:1px solid rgba(255,255,255,.08);border-radius:20px;padding:18px;max-width:320px;box-shadow:0 18px 40px rgba(0,0,0,.35)}
+.media-card__header{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+.media-card__body ul{margin:0;padding-left:18px;color:var(--muted);font-size:13px;display:grid;gap:8px}
+.badge{display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:999px;background:rgba(6,182,212,.16);color:var(--brand);font-size:12px;font-weight:600}
+.badge.ghost{background:rgba(255,255,255,.08);color:var(--text)}
+.eyebrow{font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--brand);display:block;margin-bottom:8px}
+
+.features-section{padding:48px 0 64px}
+.section-header{text-align:center;max-width:680px;margin:0 auto 36px}
+.section-header p{color:var(--muted);font-size:15px}
+.features-grid{display:grid;gap:18px}
+.feature-card{background:linear-gradient(160deg,rgba(17,26,45,.9),rgba(10,17,30,.9));border:1px solid rgba(255,255,255,.06);border-radius:18px;padding:22px;display:grid;gap:12px}
+.feature-card h3{margin:0;font-size:20px}
+.feature-card p{margin:0;color:var(--muted)}
+.inline-link{color:var(--brand);font-weight:600}
+
+.spotlight{padding:0 0 64px}
+.spotlight-card{background:linear-gradient(150deg,rgba(11,22,38,.95),rgba(6,11,24,.9));border:1px solid rgba(255,255,255,.08);border-radius:24px;padding:32px;display:grid;gap:24px;box-shadow:0 24px 50px rgba(0,0,0,.35)}
+.spotlight__body ol{margin:0;padding-left:22px;color:var(--muted);display:grid;gap:12px;font-size:15px}
+.spotlight__cta{display:flex;gap:12px;flex-wrap:wrap}
+
+.cta{padding:0 0 72px}
+.cta-card{background:linear-gradient(160deg,rgba(6,182,212,.12),rgba(6,11,24,.92));border:1px solid rgba(6,182,212,.24);border-radius:24px;padding:32px;display:flex;justify-content:space-between;align-items:center;gap:24px;flex-wrap:wrap}
+
+.landing-footer{text-align:center;padding:32px 16px;color:var(--muted);font-size:13px;border-top:1px solid rgba(255,255,255,.04);background:rgba(6,11,24,.9)}
+
+.login-page{min-height:100vh;background:linear-gradient(120deg,#071121 0%,#060b18 30%,#0c1a33 100%)}
+.login-layout{display:grid;gap:32px;padding:32px 16px 72px}
+.login-side{display:grid;gap:24px}
+.login-side__cards{display:grid;gap:16px}
+.info-card{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:18px;padding:18px}
+.info-card.ghost{background:transparent;border:1px dashed rgba(255,255,255,.2);text-align:center;padding:24px}
+.login-main{display:grid;gap:24px}
+.login-panels{display:grid;gap:18px}
+.card.glass{background:rgba(12,20,38,.82);border:1px solid rgba(255,255,255,.12);backdrop-filter:blur(14px)}
+.login-card h2{margin-top:0;margin-bottom:4px;font-size:22px}
+.form-actions{display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin-top:12px}
+.prompt-box{width:100%;background:#060f1f;color:var(--text);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:12px;font-family:"Fira Code","Courier New",monospace;font-size:12px}
+.prompt-actions{display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin-top:16px}
+.stack-card{display:grid;gap:18px}
+.feature-list{margin:0;padding-left:20px;display:grid;gap:10px}
+.modal{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;justify-content:center;align-items:center;padding:24px;z-index:50}
+.modal.hidden{display:none}
+.modal-panel{background:rgba(8,14,26,.95);border:1px solid rgba(255,255,255,.12);border-radius:20px;padding:24px;max-width:420px;width:100%;display:grid;gap:16px}
+.modal-head{display:flex;justify-content:space-between;align-items:center;gap:12px}
+.grid.single{display:grid;gap:12px}
+
+@media(min-width:960px){
+  .hero-grid{grid-template-columns:1fr 1fr}
+  .features-grid{grid-template-columns:repeat(2,1fr)}
+  .login-layout{grid-template-columns:320px 1fr}
+  .login-panels{grid-template-columns:repeat(2,1fr)}
+}
+
+@media(min-width:1180px){
+  .media-frame{grid-template-columns:1fr;gap:24px}
+  .hero-copy h1{font-size:46px}
+  .login-layout{grid-template-columns:360px 1fr}
+  .features-grid{grid-template-columns:repeat(4,1fr)}
+}
+
+@media(max-width:720px){
+  .landing-header{position:static}
+  .hero{padding-top:48px}
+  .hero-copy h1{font-size:32px}
+  .cta-card{justify-content:flex-start}
+}


### PR DESCRIPTION
## Summary
- replace the home page with a refreshed marketing-style landing experience that directs visitors to the portal
- introduce a dedicated login hub that retains member, manager, and dataset generation tools from the previous landing screen
- extract shared authentication logic into a reusable script and expand styling to support the new layouts

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e1d07fbf10832082189beaf6541186